### PR TITLE
Don't overheat when genning D&D chars.

### DIFF
--- a/lampstand/reactions/dice.py
+++ b/lampstand/reactions/dice.py
@@ -16,7 +16,7 @@ def __init__():
 class Reaction(lampstand.reactions.base.Reaction):
     __name = 'Dice'
 
-    cooldown_number = 5
+    cooldown_number = 6
     cooldown_time = 120
 
     def __init__(self, connection):


### PR DESCRIPTION
Overheat after six, not five.
