### PR TITLE
Issue #7 fix: explicitly exclude choose from bible match

### DIFF
--- a/lampstand/reactions/bible.py
+++ b/lampstand/reactions/bible.py
@@ -20,11 +20,14 @@ class Reaction(lampstand.reactions.base.Reaction):
 
     def __init__(self, connection):
         self.channelMatch = re.compile(
-            '%s. (\w*) (\d+\:\S+)' %
+            '%s. (?!choose)(\w*) (\d+\:\S+)' %
             connection.nickname,
             re.IGNORECASE)
-        self.privateMatch = re.compile('(\w*) (\d+\:\S+)')
-
+        self.privateMatch = re.compile('(?!choose)(\w*) (\d+\:\S+)')
+        #The {?!choose) is a negative lookahead to make sure that
+        #this does not match strings starting with choose so that
+        #we do not gobble choose action requests (Issue #7)
+        
     def channelAction(self, connection, user, channel, message):
         matches = self.channelMatch.findall(message)
 


### PR DESCRIPTION
Fix #7 as decided on in the #7 discussion. 

Explicitly do not match requests starting with choose so that
choose can grab them instead and we don't end up with, e.g.
Lampstand: Choose 9:30 train or 11:30 train
producing
ERROR: No passage found for your query [ESV]

Rebased as requested.
